### PR TITLE
Make GM2MModelMetaclass hashable for migrations

### DIFF
--- a/gm2m/helpers.py
+++ b/gm2m/helpers.py
@@ -88,6 +88,9 @@ class GM2MModelMetaclass(type):
     def __str__(cls):
         return RECURSIVE_RELATIONSHIP_CONSTANT
 
+    def __hash__(cls):
+        return hash(RECURSIVE_RELATIONSHIP_CONSTANT)
+
     def __iter__(cls):
         yield None
 


### PR DESCRIPTION
This method is required for django migrations
See:

https://github.com/django/django/blob/master/django/db/migrations/state.py#L35