### PR TITLE
Django 5.1 compatibility, update relation .is_hidden() to .hidden prop

### DIFF
--- a/gm2m/relations.py
+++ b/gm2m/relations.py
@@ -198,9 +198,9 @@ class GM2MUnitRel(ForeignObjectRel):
             return []
 
         # If the field doesn't install backward relation on the target
-        # model (so `is_hidden` returns True), then there are no clashes to
+        # model (so `hidden` returns True), then there are no clashes to
         # check and we can skip these fields.
-        if self.is_hidden():
+        if self.hidden:
             return []
 
         try:
@@ -355,7 +355,7 @@ class GM2MUnitRel(ForeignObjectRel):
 
         # Internal M2Ms (i.e., those with a related name ending with '+')
         # and swapped models don't get a related descriptor.
-        if not self.is_hidden() and not self.field.model._meta.swapped:
+        if not self.hidden and not self.field.model._meta.swapped:
             setattr(self.model, self.related_name
                         or (self.field.model._meta.model_name + '_set'),
                     RelatedGM2MDescriptor(self.related, self))

--- a/tests/hiddenrel/tests.py
+++ b/tests/hiddenrel/tests.py
@@ -10,7 +10,7 @@ class ReverseRelationTests(base.TestCase):
 
     def test_reverse_access(self):
         self.assertTrue(
-            self.models.Links.related_objects.field.remote_field.rels[0].is_hidden())
+            self.models.Links.related_objects.field.remote_field.rels[0].hidden)
         with self.assertRaises(AttributeError):
             getattr(self.project, 'related_links+')
 


### PR DESCRIPTION
Django introduced a new `.hidden` property around 1.9. The relation `is_hidden()` method was removed in Django 5.1. This simple change replaces calls to the removed method for the replacement property. It should work on all supported Django versions.

Can't work out quickly how to run module tests locally, relying on PR workflow to run tests. Will fix any errors found.

Fixes #67 