### PR TITLE
Add support for Django 5.2 and Python 3.13

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This django application exposes a ``GM2MField`` that combines
 the features of the standard Django ``ManyToManyField`` and
 ``GenericForeighKey`` and that can be used exactly the same way.
 
-It has been tested with Django 2.2.*, 3.0.*, 3.1.*, 3.2.*, 4.0.*, 4.1.*, 4.2.*, 5.0.*, 5.1.* and their compatible Python versions (3.8 to 3.12).
+It has been tested with Django 2.2.*, 3.0.*, 3.1.*, 3.2.*, 4.0.*, 4.1.*, 4.2.*, 5.0.*, 5.1.*, 5.2.* and their compatible Python versions (3.8 to 3.13).
 
 If you like django-gm2m and find it useful, you may want to thank me and
 encourage future development by sending a few mBTC / mBCH / mBSV at this address:

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,19 @@
 envlist =
     # Django pre-release
     py312djpre,
+    py313djpre,
+
+    # Django 5.2
+    py310dj52,
+    py311dj52,
+    py312dj52,
+    py313dj52,
 
     # Django 5.1
     py310dj51,
     py311dj51,
     py312dj51,
+    py313dj51,
 
     # Django 5.0
     py310dj50,
@@ -62,6 +70,9 @@ deps_djpre =
     {[testenv]deps}
     # using pip_pre, no need to specify version
     Django
+deps_dj52 =
+    {[testenv]deps}
+    Django>=5.2,<6.0
 deps_dj51 =
     {[testenv]deps}
     Django>=5.1,<5.2
@@ -104,6 +115,29 @@ pip_pre = True
 basepython = python3.12
 deps = {[testenv]deps_djpre}
 
+[testenv:py313djpre]
+pip_pre = True
+basepython = python3.13
+deps = {[testenv]deps_djpre}
+
+# Django 5.2
+
+[testenv:py310dj52]
+basepython = python3.10
+deps = {[testenv]deps_dj52}
+
+[testenv:py311dj52]
+basepython = python3.11
+deps = {[testenv]deps_dj52}
+
+[testenv:py312dj52]
+basepython = python3.12
+deps = {[testenv]deps_dj52}
+
+[testenv:py313dj52]
+basepython = python3.13
+deps = {[testenv]deps_dj52}
+
 # Django 5.1
 
 [testenv:py310dj51]
@@ -116,6 +150,10 @@ deps = {[testenv]deps_dj51}
 
 [testenv:py312dj51]
 basepython = python3.12
+deps = {[testenv]deps_dj51}
+
+[testenv:py313dj51]
+basepython = python3.13
 deps = {[testenv]deps_dj51}
 
 # Django 5.0


### PR DESCRIPTION
Fix #71

I've run test locally with tox for Python 3.13 and Django 5.1/5.2 without any issues.