### PR TITLE
Add support for Django 6.0 and Python 3.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ doc/_build
 # python binary files
 *.pyc
 __pycache__
+
+# IDEs
+.idea

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ key:
 | \- deletion
 
 
+v1.4 (TBD)
+-----------------
+
+| \+ Add support for Django 6.0
+| \+ Add support for Python 3.14
+
+
 v1.3 (11-11-2025)
 -----------------
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This django application exposes a ``GM2MField`` that combines
 the features of the standard Django ``ManyToManyField`` and
 ``GenericForeighKey`` and that can be used exactly the same way.
 
-It has been tested with Django 2.2.*, 3.0.*, 3.1.*, 3.2.*, 4.0.*, 4.1.*, 4.2.*, 5.0.*, 5.1.*, 5.2.* and their compatible Python versions (3.8 to 3.13).
+It has been tested with Django 2.2.*, 3.0.*, 3.1.*, 3.2.*, 4.0.*, 4.1.*, 4.2.*, 5.0.*, 5.1.*, 5.2.*, 6.0.* and their compatible Python versions (3.8 to 3.14).
 
 If you like django-gm2m and find it useful, you may want to thank me and
 encourage future development by sending a few mBTC / mBCH / mBSV at this address:

--- a/gm2m/managers.py
+++ b/gm2m/managers.py
@@ -31,7 +31,7 @@ class GM2MBaseManager(Manager):
     def _get_queryset(self, using):
         return super(GM2MBaseManager, self).get_queryset().using(using)
 
-    def get_prefetch_queryset(self, instances, queryset=None):
+    def _get_prefetch_querysets(self, instances, queryset=None):
         db = self._db or router.db_for_read(self.model,
                                             instance=instances[0])
 
@@ -47,6 +47,24 @@ class GM2MBaseManager(Manager):
                 False,
                 self.prefetch_cache_name,
                 False)
+
+    if django.VERSION < (5, 0):
+        # get_prefetch_queryset() deprecated in favor of
+        # get_prefetch_querysets() in Django 5.0, dropped in 6.0
+        def get_prefetch_queryset(self, instances, queryset=None):
+            return self._get_prefetch_querysets(instances, queryset)
+    else:
+        def get_prefetch_querysets(self, instances, querysets=None):
+            if querysets and len(querysets) != 1:
+                # Django's M2M don't support passing multiple querysets
+                # https://github.com/django/django/blob/b7e5bc37eec7d5c33bc0d32d4b0fdf46a68661aa/django/db/models/fields/related_descriptors.py#L817  # noqa
+                # https://github.com/django/django/blob/b7e5bc37eec7d5c33bc0d32d4b0fdf46a68661aa/django/db/models/fields/related_descriptors.py#L1199  # noqa
+                raise ValueError(
+                    'querysets argument of get_prefetch_querysets() should '
+                    'have a length of 1.'
+                )
+            queryset = querysets[0] if querysets else None
+            return self._get_prefetch_querysets(instances, queryset)
 
     def _get_extra_queryset(self, queryset, q, extra_fields, db):
         join_table = self.through._meta.db_table

--- a/gm2m/version.py
+++ b/gm2m/version.py
@@ -1,6 +1,6 @@
 import subprocess
 
-__version_info__ = (1, 3, 0, 'final', 0)
+__version_info__ = (1, 4, 0, 'final', 0)
 
 
 def get_version(version=__version_info__):

--- a/tests/norevrel/tests_migrations.py
+++ b/tests/norevrel/tests_migrations.py
@@ -11,7 +11,10 @@ class MigrationTests(base.MigrationsTestCase):
     def test_makemigrations(self):
         self.makemigrations()
 
-        mig_ctnt = re.sub(r'models\.AutoField\(.+?\)', 'models.AutoField()',
+        # DEFAULT_AUTO_FIELD changed to BigAutoField in Django 6.0, normalize it
+        field = 'BigAutoField' if django.VERSION >= (6, 0) else 'AutoField'
+
+        mig_ctnt = re.sub(rf'models\.{field}\(.+?\)', 'models.AutoField()',
                           self.get_migration_content())
         mig_ctnt = re.sub(r"([\s\(])b'", r"\1'", mig_ctnt)
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,19 @@ envlist =
     # Django pre-release
     py312djpre,
     py313djpre,
+    py314djpre,
+
+    # Django 6.0
+    py312dj60,
+    py313dj60,
+    py314dj60,
 
     # Django 5.2
     py310dj52,
     py311dj52,
     py312dj52,
     py313dj52,
+    py314dj52,
 
     # Django 5.1
     py310dj51,
@@ -70,6 +77,9 @@ deps_djpre =
     {[testenv]deps}
     # using pip_pre, no need to specify version
     Django
+deps_dj60 =
+    {[testenv]deps}
+    Django>=6.0,<6.1
 deps_dj52 =
     {[testenv]deps}
     Django>=5.2,<6.0
@@ -120,6 +130,25 @@ pip_pre = True
 basepython = python3.13
 deps = {[testenv]deps_djpre}
 
+[testenv:py314djpre]
+pip_pre = True
+basepython = python3.14
+deps = {[testenv]deps_djpre}
+
+# Django 6.0
+
+[testenv:py312dj60]
+basepython = python3.12
+deps = {[testenv]deps_dj60}
+
+[testenv:py313dj60]
+basepython = python3.13
+deps = {[testenv]deps_dj60}
+
+[testenv:py314dj60]
+basepython = python3.14
+deps = {[testenv]deps_dj60}
+
 # Django 5.2
 
 [testenv:py310dj52]
@@ -136,6 +165,10 @@ deps = {[testenv]deps_dj52}
 
 [testenv:py313dj52]
 basepython = python3.13
+deps = {[testenv]deps_dj52}
+
+[testenv:py314dj52]
+basepython = python3.14
 deps = {[testenv]deps_dj52}
 
 # Django 5.1


### PR DESCRIPTION
This PR adds support for Django 6.0 and Python 3.14.

Tests passed, [tox-full.log](https://github.com/user-attachments/files/28534220/tox-full.log)
